### PR TITLE
Fix c++ and cmake examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ make
 make install
 ```
 
-To use franky, you can also include it as a subproject in your parent CMake via `add_subdirectory(franky)` and then `target_link_libraries(<target> libfranky)`. 
+To use franky, you can also include it as a subproject in your parent CMake via `add_subdirectory(franky)` and then `target_link_libraries(<target> franky)`. 
 
 If you need only the Python module, you can install franky via
 ```bash
@@ -179,10 +179,10 @@ using namespace franky;
 Robot robot("172.16.0.2");
 
 // Reduce velocity and acceleration of the robot
-robot.setDynamicRel(0.05);
+robot.setRelativeDynamicsFactor(0.05);
 
 // Move the end-effector 20cm in positive x-direction
-auto motion = CartesianMotion(RobotPose(Affine({0.2, 0.0, 0.0}), 0.0), ReferenceType::Relative);
+auto motion = std::make_shared<CartesianMotion>(RobotPose(Affine({0.2, 0.0, 0.0}), 0.0), ReferenceType::Relative);
 
 // Finally move the robot
 robot.move(motion);


### PR DESCRIPTION
The [C++ example in the readme](https://github.com/TimSchneider42/franky/blob/269b5cceec5830935290405f2fa0485d94a7200e/README.md?plain=1#L174-L188) did not compile, due to the following errors:

```
error: ‘class franky::Robot’ has no member named ‘setDynamicRel’
error: no matching function for call to ‘franky::Robot::move(franky::CartesianMotion&)’
```

Also, when linking to a CMake target, the name of the target has to be provided without a "lib" prefix. In this case here, [the name of the target is `franky`](https://github.com/TimSchneider42/franky/blob/269b5cceec5830935290405f2fa0485d94a7200e/CMakeLists.txt#L32).