### PR TITLE
Improvements to `RobotWebSession`

### DIFF
--- a/franky/robot_web_session.py
+++ b/franky/robot_web_session.py
@@ -155,7 +155,7 @@ class RobotWebSession:
         force: bool = False,
         retry_with_force: bool = True,
     ):
-        if not self.has_control() or force:
+        if not self.has_control():
             res = self.send_api_request(
                 f"/admin/api/control-token/request{'?force' if force else ''}",
                 headers={"content-type": "application/json"},
@@ -176,7 +176,7 @@ class RobotWebSession:
                 time.sleep(max(0.0, min(1.0, wait_timeout - (time.time() - start))))
                 has_control = self.has_control()
             if not has_control:
-                if retry_with_force and not force:
+                if retry_with_force:
                     # use much longer timeout to allow user to physically press button
                     return self.take_control(
                         wait_timeout=30.0, force=True, retry_with_force=False


### PR DESCRIPTION
This PR implements two changes:

1. The web session **always times out for me** before the unlocking of the brakes can complete! To fix this, I expose the timeout parameter of the `open()` function and set it to a 30s default, up from 12s on `master`.
2. I expose a `force` boolean in the `take_control` function so that if the robot is currently not under control in the current program, the user can manually click the top button on the FR3 to acquire control.

It would be great if these changes could be merged and a new release put out so that I can `pip` install `franky` and use the following workflow:
```python
web_session = RobotWebSession(
    fci_hostname=<robot_ip>,
    username=<username>,
    password=<password>,
)
web_session.open()
success = web_session.take_control(force=False)
if not success:
    web_session.take_control(force=True)
web_session.unlock_brakes()
```