### PR TITLE
Expose motion attributes

### DIFF
--- a/include/franky/motion/cartesian_velocity_waypoint_motion.hpp
+++ b/include/franky/motion/cartesian_velocity_waypoint_motion.hpp
@@ -35,6 +35,8 @@ class CartesianVelocityWaypointMotion : public VelocityWaypointMotion<franka::Ca
       const std::vector<VelocityWaypoint<RobotVelocity>> &waypoints,
       const RelativeDynamicsFactor &relative_dynamics_factor = 1.0, Affine ee_frame = Affine::Identity());
 
+  [[nodiscard]] const Affine &ee_frame() const { return ee_frame_; }
+
  protected:
   void checkWaypoint(const VelocityWaypoint<RobotVelocity> &waypoint) const override;
 

--- a/include/franky/motion/cartesian_waypoint_motion.hpp
+++ b/include/franky/motion/cartesian_waypoint_motion.hpp
@@ -39,6 +39,8 @@ class CartesianWaypointMotion : public PositionWaypointMotion<franka::CartesianP
       const RelativeDynamicsFactor &relative_dynamics_factor = 1.0, bool return_when_finished = true,
       Affine ee_frame = Affine::Identity());
 
+  [[nodiscard]] const Affine &ee_frame() const { return ee_frame_; }
+
  protected:
   void initWaypointMotion(
       const RobotState &robot_state, const std::optional<franka::CartesianPose> &previous_command,

--- a/include/franky/motion/position_waypoint_motion.hpp
+++ b/include/franky/motion/position_waypoint_motion.hpp
@@ -46,6 +46,8 @@ class PositionWaypointMotion : public WaypointMotion<ControlSignalType, Position
       : WaypointMotion<ControlSignalType, PositionWaypoint<TargetType>, TargetType>(waypoints, return_when_finished),
         relative_dynamics_factor_(relative_dynamics_factor) {}
 
+  [[nodiscard]] const RelativeDynamicsFactor &relative_dynamics_factor() const { return relative_dynamics_factor_; }
+
  protected:
   void setInputLimits(
       const PositionWaypoint<TargetType> &waypoint, ruckig::InputParameter<7> &input_parameter) const override {

--- a/include/franky/motion/velocity_waypoint_motion.hpp
+++ b/include/franky/motion/velocity_waypoint_motion.hpp
@@ -39,6 +39,8 @@ class VelocityWaypointMotion : public WaypointMotion<ControlSignalType, Velocity
       : WaypointMotion<ControlSignalType, VelocityWaypoint<TargetType>, TargetType>(waypoints, true),
         relative_dynamics_factor_(relative_dynamics_factor) {}
 
+  [[nodiscard]] const RelativeDynamicsFactor &relative_dynamics_factor() const { return relative_dynamics_factor_; }
+
  protected:
   void setInputLimits(
       const VelocityWaypoint<TargetType> &waypoint, ruckig::InputParameter<7> &input_parameter) const override {

--- a/include/franky/motion/waypoint_motion.hpp
+++ b/include/franky/motion/waypoint_motion.hpp
@@ -69,6 +69,10 @@ class WaypointMotion : public Motion<ControlSignalType> {
   explicit WaypointMotion(std::vector<WaypointType> waypoints, bool return_when_finished = true)
       : waypoints_(std::move(waypoints)), return_when_finished_(return_when_finished), prev_result_() {}
 
+  [[nodiscard]] const std::vector<WaypointType> &waypoints() const { return waypoints_; }
+
+  [[nodiscard]] bool return_when_finished() const { return return_when_finished_; }
+
  protected:
   void initImpl(const RobotState &robot_state, const std::optional<ControlSignalType> &previous_command) override {
     target_reached_time_ = std::nullopt;

--- a/python/bind_motion_cartesian_pos.cpp
+++ b/python/bind_motion_cartesian_pos.cpp
@@ -49,7 +49,11 @@ void bind_motion_cartesian_pos(py::module &m) {
           "waypoints"_a,
           "ee_frame"_a = std::nullopt,
           "relative_dynamics_factor"_a = 1.0,
-          "return_when_finished"_a = true);
+          "return_when_finished"_a = true)
+      .def_property_readonly("waypoints", &CartesianWaypointMotion::waypoints)
+      .def_property_readonly("ee_frame", &CartesianWaypointMotion::ee_frame)
+      .def_property_readonly("relative_dynamics_factor", &CartesianWaypointMotion::relative_dynamics_factor)
+      .def_property_readonly("return_when_finished", &CartesianWaypointMotion::return_when_finished);
 
   py::class_<CartesianMotion, CartesianWaypointMotion, std::shared_ptr<CartesianMotion>>(m, "CartesianMotion")
       .def(
@@ -69,11 +73,15 @@ void bind_motion_cartesian_pos(py::module &m) {
           py::arg_v("reference_type", ReferenceType::kAbsolute, "_franky.ReferenceType.Absolute"),
           "relative_dynamics_factor"_a = 1.0,
           "return_when_finished"_a = true,
-          "ee_frame"_a = std::nullopt);
+          "ee_frame"_a = std::nullopt)
+      .def_property_readonly("target", [](const CartesianMotion &motion) { return motion.waypoints().front().target; })
+      .def_property_readonly(
+          "reference_type", [](const CartesianMotion &motion) { return motion.waypoints().front().reference_type; });
 
   py::class_<
       StopMotion<franka::CartesianPose>,
       Motion<franka::CartesianPose>,
       std::shared_ptr<StopMotion<franka::CartesianPose>>>(m, "CartesianStopMotion")
-      .def(py::init<RelativeDynamicsFactor>(), "relative_dynamics_factor"_a = 1.0);
+      .def(py::init<RelativeDynamicsFactor>(), "relative_dynamics_factor"_a = 1.0)
+      .def_property_readonly("relative_dynamics_factor", &StopMotion<franka::CartesianPose>::relative_dynamics_factor);
 }

--- a/python/bind_motion_cartesian_vel.cpp
+++ b/python/bind_motion_cartesian_vel.cpp
@@ -45,7 +45,10 @@ void bind_motion_cartesian_vel(py::module &m) {
           }),
           "waypoints"_a,
           "ee_frame"_a = std::nullopt,
-          "relative_dynamics_factor"_a = 1.0);
+          "relative_dynamics_factor"_a = 1.0)
+      .def_property_readonly("waypoints", &CartesianVelocityWaypointMotion::waypoints)
+      .def_property_readonly("ee_frame", &CartesianVelocityWaypointMotion::ee_frame)
+      .def_property_readonly("relative_dynamics_factor", &CartesianVelocityWaypointMotion::relative_dynamics_factor);
 
   py::class_<CartesianVelocityMotion, CartesianVelocityWaypointMotion, std::shared_ptr<CartesianVelocityMotion>>(
       m, "CartesianVelocityMotion")
@@ -60,11 +63,18 @@ void bind_motion_cartesian_vel(py::module &m) {
           "target"_a,
           "duration"_a = franka::Duration(1000),
           "relative_dynamics_factor"_a = 1.0,
-          "ee_frame"_a = std::nullopt);
+          "ee_frame"_a = std::nullopt)
+      .def_property_readonly(
+          "target", [](const CartesianVelocityMotion &motion) { return motion.waypoints().front().target; })
+      .def_property_readonly("duration", [](const CartesianVelocityMotion &motion) {
+        return motion.waypoints().front().hold_target_duration;
+      });
 
   py::class_<
       StopMotion<franka::CartesianVelocities>,
       Motion<franka::CartesianVelocities>,
       std::shared_ptr<StopMotion<franka::CartesianVelocities>>>(m, "CartesianVelocityStopMotion")
-      .def(py::init<RelativeDynamicsFactor>(), "relative_dynamics_factor"_a = 1.0);
+      .def(py::init<RelativeDynamicsFactor>(), "relative_dynamics_factor"_a = 1.0)
+      .def_property_readonly(
+          "relative_dynamics_factor", &StopMotion<franka::CartesianVelocities>::relative_dynamics_factor);
 }

--- a/python/bind_motion_joint_pos.cpp
+++ b/python/bind_motion_joint_pos.cpp
@@ -46,7 +46,10 @@ void bind_motion_joint_pos(py::module &m) {
           }),
           "waypoints"_a,
           "relative_dynamics_factor"_a = 1.0,
-          "return_when_finished"_a = true);
+          "return_when_finished"_a = true)
+      .def_property_readonly("waypoints", &JointWaypointMotion::waypoints)
+      .def_property_readonly("relative_dynamics_factor", &JointWaypointMotion::relative_dynamics_factor)
+      .def_property_readonly("return_when_finished", &JointWaypointMotion::return_when_finished);
 
   py::class_<JointMotion, JointWaypointMotion, std::shared_ptr<JointMotion>>(m, "JointMotion")
       .def(
@@ -54,11 +57,15 @@ void bind_motion_joint_pos(py::module &m) {
           "target"_a,
           py::arg_v("reference_type", ReferenceType::kAbsolute, "_franky.ReferenceType.Absolute"),
           "relative_dynamics_factor"_a = 1.0,
-          "return_when_finished"_a = true);
+          "return_when_finished"_a = true)
+      .def_property_readonly("target", [](const JointMotion &motion) { return motion.waypoints().front().target; })
+      .def_property_readonly(
+          "reference_type", [](const JointMotion &motion) { return motion.waypoints().front().reference_type; });
 
   py::class_<
       StopMotion<franka::JointPositions>,
       Motion<franka::JointPositions>,
       std::shared_ptr<StopMotion<franka::JointPositions>>>(m, "JointStopMotion")
-      .def(py::init<RelativeDynamicsFactor>(), "relative_dynamics_factor"_a = 1.0);
+      .def(py::init<RelativeDynamicsFactor>(), "relative_dynamics_factor"_a = 1.0)
+      .def_property_readonly("relative_dynamics_factor", &StopMotion<franka::JointPositions>::relative_dynamics_factor);
 }

--- a/python/bind_motion_joint_vel.cpp
+++ b/python/bind_motion_joint_vel.cpp
@@ -42,7 +42,9 @@ void bind_motion_joint_vel(py::module &m) {
             return std::make_shared<JointVelocityWaypointMotion>(waypoints, relative_dynamics_factor);
           }),
           "waypoints"_a,
-          "relative_dynamics_factor"_a = 1.0);
+          "relative_dynamics_factor"_a = 1.0)
+      .def_property_readonly("waypoints", &JointVelocityWaypointMotion::waypoints)
+      .def_property_readonly("relative_dynamics_factor", &JointVelocityWaypointMotion::relative_dynamics_factor);
 
   py::class_<JointVelocityMotion, JointVelocityWaypointMotion, std::shared_ptr<JointVelocityMotion>>(
       m, "JointVelocityMotion")
@@ -50,11 +52,18 @@ void bind_motion_joint_vel(py::module &m) {
           py::init<const Vector7d &, franka::Duration, RelativeDynamicsFactor>(),
           "target"_a,
           "duration"_a = franka::Duration(1000),
-          "relative_dynamics_factor"_a = 1.0);
+          "relative_dynamics_factor"_a = 1.0)
+      .def_property_readonly(
+          "target", [](const JointVelocityMotion &motion) { return motion.waypoints().front().target; })
+      .def_property_readonly("duration", [](const JointVelocityMotion &motion) {
+        return motion.waypoints().front().hold_target_duration;
+      });
 
   py::class_<
       StopMotion<franka::JointVelocities>,
       Motion<franka::JointVelocities>,
       std::shared_ptr<StopMotion<franka::JointVelocities>>>(m, "JointVelocityStopMotion")
-      .def(py::init<RelativeDynamicsFactor>(), "relative_dynamics_factor"_a = 1.0);
+      .def(py::init<RelativeDynamicsFactor>(), "relative_dynamics_factor"_a = 1.0)
+      .def_property_readonly(
+          "relative_dynamics_factor", &StopMotion<franka::JointVelocities>::relative_dynamics_factor);
 }


### PR DESCRIPTION
Motion objects (CartesianMotion, JointMotion, waypoint variants, and stop motions) accepted parameters like `waypoints`, `relative_dynamics_factor`, `ee_frame`, and `return_when_finished` at construction but provided no way to read them back. This made it impossible to inspect a motion after the fact. My use case for this is that I'd like to serialize motion commands.

This PR adds read-only accessors in C++ and exposes them as `@property` on the Python side. The convenience motion classes (CartesianMotion, JointMotion, etc.) also get target and reference_type properties derived from their single waypoint.

```python
motion = CartesianMotion(target, relative_dynamics_factor=0.5)
robot.move(motion)

# now inspectable:
print(motion.target)                   # the Affine target
print(motion.relative_dynamics_factor) # 0.5
print(motion.return_when_finished)     # True
```