### PR TITLE
Fix estimated EE twist frame

### DIFF
--- a/include/franky/model.hpp
+++ b/include/franky/model.hpp
@@ -49,7 +49,7 @@ class Model {
   [[nodiscard]] Affine pose(franka::Frame frame, const Vector7d &q, const Affine &F_T_EE, const Affine &EE_T_K) const;
 
   /**
-   * @brief Calculates the body Jacobian in base frame.
+   * @brief Calculates the body Jacobian in the given frame.
    *
    * @param frame The frame for which the Jacobian is computed.
    * @param state The current robot state.
@@ -58,7 +58,7 @@ class Model {
   [[nodiscard]] Jacobian bodyJacobian(franka::Frame frame, const RobotState &state) const;
 
   /**
-   * @brief Calculates the body Jacobian in base frame.
+   * @brief Calculates the body Jacobian in the given frame.
    *
    * @param frame The frame for which the Jacobian is computed.
    * @param q Robot joint angles [rad].

--- a/src/robot_state_estimator.cpp
+++ b/src/robot_state_estimator.cpp
@@ -97,7 +97,7 @@ RobotState RobotStateEstimator::update(const franka::RobotState &franka_robot_st
     }
   }
 
-  const auto ee_jacobian = model.bodyJacobian(
+  const auto ee_jacobian = model.zeroJacobian(
       franka::Frame::kEndEffector,
       toEigenD(franka_robot_state.q),
       stdToAffine(franka_robot_state.F_T_EE),


### PR DESCRIPTION
Docs said the estimate is in base frame, 

```cpp
/**
 * Estimated end-effector twist (linear and angular velocity) expressed in
 * @ref o-frame "base frame". Computed by franky; not provided by franka
 * firmware. Unit:
 * \f$[\frac{m}{s},\frac{m}{s},\frac{m}{s},\frac{rad}{s},\frac{rad}{s},\frac{rad}{s}]\f$.
 */
std::optional<Twist> O_dP_EE_est{};

```

but it was in end effector frame. libfranka:

```cpp
/**
* Gets the 6x7 Jacobian for the given frame, relative to that frame.
*
* The Jacobian is represented as a 6x7 matrix in column-major format.
*
* @param[in] frame The desired frame.
* @param[in] q Joint position.
* @param[in] F_T_EE End effector in flange frame.
* @param[in] EE_T_K Stiffness frame K in the end effector frame.
*
* @return Vectorized 6x7 Jacobian, column-major.
*/
std::array<double, 42> bodyJacobian(
  Frame frame,
  const std::array<double, 7>& q,        // NOLINT(readability-identifier-length)
  const std::array<double, 16>& F_T_EE,  // NOLINT(readability-identifier-naming)
  const std::array<double, 16>& EE_T_K)  // NOLINT(readability-identifier-naming)
  const;
```

Switch to zeroJacobian to match the docs. Also clarified docs for bodyJacobian method wrapper.